### PR TITLE
fix 修复无双模式无法切换角色的问题

### DIFF
--- a/CORE_KernelLogic/global/GetLang.as
+++ b/CORE_KernelLogic/global/GetLang.as
@@ -43,9 +43,19 @@ package {
 public function GetLang(tree:String, ...args):String {
     // 当前语言文本
     var langText:String = GetLangText(tree);
-    // 格式化后的当前语言
-    var format:String   = Format(langText, args);
 
-    return format;
-}
+    // 确保替换占位符数量匹配
+    var placeholderCount:int = (langText.match(/{}/g) || []).length;
+
+    if (placeholderCount != args.length) {
+        throw new Error("GetLang:: The variadic length does not match the formatted string length!");
+    }
+
+    // 替换占位符
+    for (var i:int = 0; i < args.length; i++) {
+        langText = langText.replace("{}", args[i].toString());
+    }
+
+    return langText;
+  }
 }

--- a/CORE_KernelLogic/global/TraceLang.as
+++ b/CORE_KernelLogic/global/TraceLang.as
@@ -41,7 +41,7 @@ package {
  */
 public function TraceLang(tree:String, ...args):void {
     // 输出内容
-    var format:String = GetLang(tree, args);
+    var format:String = GetLang.apply(null, [tree].concat(args));
 
     Trace(format);
 }

--- a/CORE_KernelLogic/src/net/play5d/game/bvn/ctrler/mosou_ctrls/MosouCtrl.as
+++ b/CORE_KernelLogic/src/net/play5d/game/bvn/ctrler/mosou_ctrls/MosouCtrl.as
@@ -325,8 +325,6 @@ public class MosouCtrl {
         to.fzqi   = to.fzqiMax;
         to.direct = from.direct;
 
-        TraceLang('debug.trace.data.musou_ctrl.show_fzqi', to.fzqi, to.fzqiMax);
-
         if (to.initlized()) {
             GameCtrl.I.addGameSprite(to.team.id, to);
         }
@@ -346,6 +344,10 @@ public class MosouCtrl {
         to.updatePosition();
 
         updateCamera();
+
+
+        TraceLang('debug.trace.data.musou_ctrl.show_fzqi',to.fzqi);
+        TraceLang('debug.trace.data.musou_ctrl.show_fzqi_max',to.fzqiMax);
     }
 
     public function updateEnemy(v:FighterMain):void {

--- a/shared/assets/assets/config/language/zh-CN.json
+++ b/shared/assets/assets/config/language/zh-CN.json
@@ -104,7 +104,8 @@
           "self_die_complete"        : "无双模式的 onSelfDead 事件完成！",
           "mission_complete"         : "无双模式的任务完成！",
           "mission_complete_complete": "无双模式的 missionComplete 事件完成！",
-          "show_fzqi"                : "辅助能量 (FZQI) ======================= fzqi: {}, fzqiMax: {}",
+          "show_fzqi"                : "辅助能量 : fzqi: {}",
+          "show_fzqi_max"             : "最大辅助能量 : fzqiMax: {}",
           "boss_die"                 : "无双模式的 BOSS 死亡！"
         },
         "musou_enemy_bar_ctrl": {


### PR DESCRIPTION
报错: ArgumentError: The variadic length does not match the formatted string length! 
原因 因为Foramt方法无法识别多个参数并错误的跳出报错
解决方法::
因Format方法使用次数过多 暂时不动他 重构了TraceLang和GetLang 方法 。
1) traceLang 方法 使用 apply方法将 **tree** 和 **args** 参数组合成一个数组传递给 GetLang 方法
2) 在getLang 方法中使用循环遍历替换占位符内内容 不通过Format进行格式化